### PR TITLE
Made __init__ more tidy

### DIFF
--- a/skewer/__init__.py
+++ b/skewer/__init__.py
@@ -1,20 +1,3 @@
-from skewer.utils import clean_path
-import sys
-import os
+from .skewer import extend_skewer
 
-
-try:
-    # check if module was called by pymol, if yes run skewer.main
-    main_initfile = sys.modules['__main__'].__file__
-
-    # get the name of the parent module
-    main_modulename = os.path.basename(clean_path(os.path.join(main_initfile, os.pardir)))
-
-except AttributeError:
-    # importing from an interpreter like ipython raises this error
-    main_modulename = None
-
-
-if main_modulename == 'pymol':
-    from skewer.skewer import load
-    load()
+extend_skewer()

--- a/skewer/skewer.py
+++ b/skewer/skewer.py
@@ -27,9 +27,10 @@ import numpy as np
 from glob import glob
 
 # local imports
-from skewer.parse_tpr import parse_tpr
-from skewer.parse_top import parse_top
-from skewer.utils import clean_path, get_chain_bb
+# This is how you do relative imports
+from .parse_tpr import parse_tpr
+from .parse_top import parse_top
+from .utils import clean_path, get_chain_bb, extension
 
 
 def make_graphs(system):
@@ -215,7 +216,8 @@ ARGUMENTS
 #        cmd.show_as("cartoon", selection + " and (name BB or name CA)")
 
 
-def load():
+@extension
+def extend_skewer():
     cmd.extend('skewer', skewer)
 
     # tab completion for the skewer command
@@ -227,6 +229,6 @@ def load():
     cmd.auto_arg[1]['skewer'] = [cmd.object_sc, 'selection', '']
 
 
-# make sure it can be run as a script for simplicity
-if __name__ == 'pymol':
-    load()
+## make sure it can be run as a script for simplicity
+#if __name__ == 'pymol':
+#    load()

--- a/skewer/utils.py
+++ b/skewer/utils.py
@@ -24,6 +24,7 @@ from pymol import cmd
 import shutil
 import collections
 import os
+import sys
 
 
 def get_chain_bb(selection):
@@ -71,3 +72,19 @@ def clean_path(path):
     resolves path variables, `~`, symlinks and returns a clean absolute path
     """
     return os.path.realpath(os.path.expanduser(os.path.expandvars(path)))
+
+def extension(loading_func):
+    try:
+        # check if module was called by pymol, if yes run skewer.main
+        main_initfile = sys.modules['__main__'].__file__
+    
+        # get the name of the parent module
+        main_modulename = os.path.basename(clean_path(os.path.join(main_initfile, os.pardir)))
+    
+    except AttributeError:
+        # importing from an interpreter like ipython raises this error
+        main_modulename = None
+    
+    
+    if main_modulename == 'pymol':
+        return loading_func

--- a/skewer/utils.py
+++ b/skewer/utils.py
@@ -88,3 +88,6 @@ def extension(loading_func):
     
     if main_modulename == 'pymol':
         return loading_func
+    else:
+        # Just return a passing lambda doing nothing, to avoid errors further downstream
+        return lambda: pass 

--- a/skewer/utils.py
+++ b/skewer/utils.py
@@ -90,4 +90,4 @@ def extension(loading_func):
         return loading_func
     else:
         # Just return a passing lambda doing nothing, to avoid errors further downstream
-        return lambda: pass 
+        return lambda: None

--- a/skewer/utils.py
+++ b/skewer/utils.py
@@ -74,6 +74,11 @@ def clean_path(path):
     return os.path.realpath(os.path.expanduser(os.path.expandvars(path)))
 
 def extension(loading_func):
+    """
+    Decorator for pymol extension functions.
+    Will only return the loading function if called by pymol, else returns an empty function so no errors are raised.
+    These functions can then be called in __init__.py to extend pymol functions to pymol.
+    """
     try:
         # check if module was called by pymol, if yes run skewer.main
         main_initfile = sys.modules['__main__'].__file__


### PR DESCRIPTION
i made your code for handling importing in pymol into a decorator called "extension"
I renamed the "load" function to "extend_skewer", and added the decorator.
now the pymol handling code is included in the functions.
When pymol is not there it will just return a passing lambda so nothing happens.